### PR TITLE
add createSprite function

### DIFF
--- a/src/canvas/sprite.ts
+++ b/src/canvas/sprite.ts
@@ -1,0 +1,14 @@
+export default function createSprite(
+	width: number,
+	height: number,
+	fn: (ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) => void
+) {
+	const canvas = document.createElement('canvas');
+	canvas.width = width;
+	canvas.height = height;
+	const ctx = canvas.getContext('2d');
+
+	fn(ctx, canvas);
+
+	return canvas;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export { default as shuffle } from './array/shuffle';
 // async
 export { default as queue } from './async/queue';
 
+// canvas
+export { default as createSprite } from './canvas/sprite';
+
 // number
 export { default as clamp } from './number/clamp';
 export { default as random } from './number/random';


### PR DESCRIPTION
Adds a utility for creating canvas sprites. No tests because I can't be bothered to rig up puppeteer.

```js
import { createSprite } from 'yootils';

const sprite = createSprite(32, 32, (ctx, canvas) => {
  ctx.beginPath();
  ctx.arc(canvas.width / 2, canvas.height / 2, 2, Math.PI*2, 0);
  ctx.fillStyle = 'red';
  ctx.fill();
  ctx.closePath();
});

// `sprite` is a <canvas> that you can use with `someOtherContext.drawImage(sprite, x, y)`
```